### PR TITLE
Simplify quiz layouts

### DIFF
--- a/index.html
+++ b/index.html
@@ -204,19 +204,32 @@
     .resource-links ul li {
       font-weight: bold;
     }
-    /* Keep quiz list items normal weight */
-    .quiz li {
-      font-weight: normal;
-      margin-bottom: 15px;
-    }
-    /* Make quiz questions bold */
-    .quiz li > p {
-      font-weight: bold;
-    }
     .quiz label {
       font-weight: normal;
       display: block;
       margin: 4px 0;
+    }
+    /* New single-column quiz layout */
+    .quiz-question {
+      margin-bottom: 24px;
+      padding: 12px 0;
+      border-bottom: 1px solid #ddd;
+    }
+    .question-text {
+      font-weight: 600;
+      margin-bottom: 8px;
+    }
+    .quiz-question label {
+      display: block;
+      margin: 6px 0;
+      cursor: pointer;
+    }
+    .quiz-question input[type="radio"] {
+      margin-right: 6px;
+    }
+    @media (max-width: 600px) {
+      .quiz-question { padding: 10px 0; }
+      .question-text { font-size: 1rem; }
     }
     .resource-links a {
       font-weight: bold;
@@ -531,18 +544,18 @@ function askForName() {
 }
 
 function shuffleQuizAnswers() {
-  document.querySelectorAll('form.quiz li').forEach(li => {
-    const labels = Array.from(li.querySelectorAll('label'));
+  document.querySelectorAll('form.quiz .quiz-question').forEach(q => {
+    const labels = Array.from(q.querySelectorAll('label'));
     if (labels.length <= 1) return;
-    li.querySelectorAll('br').forEach(br => br.remove());
+    q.querySelectorAll('br').forEach(br => br.remove());
     labels.forEach(l => l.remove());
     for (let i = labels.length - 1; i > 0; i--) {
       const j = Math.floor(Math.random() * (i + 1));
       [labels[i], labels[j]] = [labels[j], labels[i]];
     }
     labels.forEach((label, idx) => {
-      li.appendChild(label);
-      if (idx < labels.length - 1) li.appendChild(document.createElement('br'));
+      q.appendChild(label);
+      if (idx < labels.length - 1) q.appendChild(document.createElement('br'));
     });
   });
 }
@@ -556,7 +569,7 @@ function initQuizFeatures() {
     });
   }
   // Ensure all quiz question buttons have an aria-label
-  document.querySelectorAll('form.quiz li > p button').forEach(btn => {
+  document.querySelectorAll('form.quiz .quiz-question > p button').forEach(btn => {
     if (!btn.hasAttribute('aria-label')) {
       btn.setAttribute('aria-label', 'Read question aloud');
     }
@@ -581,8 +594,8 @@ function submitQuiz(btn, quizType) {
   const fieldset = form.querySelector('fieldset');
   let correct = 0, total = 0;
   const results = [];
-  fieldset.querySelectorAll('li').forEach((li, idx) => {
-    const radios = li.querySelectorAll('input[type=radio]');
+  fieldset.querySelectorAll('.quiz-question').forEach((q, idx) => {
+    const radios = q.querySelectorAll('input[type=radio]');
     let userCorrect = false, answered = false;
     radios.forEach(radio => {
       if (radio.checked) {
@@ -601,7 +614,7 @@ function submitQuiz(btn, quizType) {
     });
     if (userCorrect) correct += 1;
     results.push({
-      question: li.querySelector('p').textContent,
+      question: q.querySelector('p').textContent,
       answer: Array.from(radios).find(r => r.checked)?.value || ''
     });
   });
@@ -644,12 +657,12 @@ function submitAdvancedQuiz(btn, quizType) {
   const form = btn.closest('form');
   const textareas = form.querySelectorAll('textarea');
   const responses = [];
-  textareas.forEach((ta) => {
-    responses.push({
-      question: ta.closest('li').querySelector('p').textContent,
-      answer: ta.value.trim()
+    textareas.forEach((ta) => {
+      responses.push({
+        question: ta.closest('.quiz-question').querySelector('p').textContent,
+        answer: ta.value.trim()
+      });
     });
-  });
 
   const studentName = prompt('Please enter your name to submit your answers:');
   if (!studentName) return;

--- a/sections/advanced-activities/week1.html
+++ b/sections/advanced-activities/week1.html
@@ -11,24 +11,24 @@
     <form class="quiz" id="advanced-week1-quiz">
       <fieldset>
         <legend><b>Advanced Activities – Week 1 Questions</b></legend>
-        <ol>
-          <li>
-            <p>Discuss how effective risk management aligns with WHS legislation in the context of a school workshop.  Identify one hazard and explain how it could be controlled.</p>
+        
+          <div class="quiz-question">
+            <p class="question-text">Discuss how effective risk management aligns with WHS legislation in the context of a school workshop.  Identify one hazard and explain how it could be controlled.</p>
             <textarea name="adv1_q1" placeholder="Write your answer here..."></textarea>
-          </li>
-          <li>
-            <p>Compare <em>turning between centres</em> with using a chuck or faceplate.  When would you use each method?</p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">Compare <em>turning between centres</em> with using a chuck or faceplate.  When would you use each method?</p>
             <textarea name="adv1_q2" placeholder="Write your answer here..."></textarea>
-          </li>
-          <li>
-            <p>Choose two lathe tools (for example a spindle gouge and a skew chisel) and describe their different purposes when turning a pen.  Which tool gives the cleaner finish and why?</p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">Choose two lathe tools (for example a spindle gouge and a skew chisel) and describe their different purposes when turning a pen.  Which tool gives the cleaner finish and why?</p>
             <textarea name="adv1_q3" placeholder="Write your answer here..."></textarea>
-          </li>
-          <li>
-            <p>Explain why gloves are generally not recommended when using a wood lathe.  What personal protective equipment should be used instead?</p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">Explain why gloves are generally not recommended when using a wood lathe.  What personal protective equipment should be used instead?</p>
             <textarea name="adv1_q4" placeholder="Write your answer here..."></textarea>
-          </li>
-        </ol>
+          </div>
+        
         <button class="check-btn" type="button" onclick="submitAdvancedQuiz(this, 'A001')">Submit Responses</button>
         <span class="quiz-msg"></span>
       </fieldset>

--- a/sections/advanced-activities/week2.html
+++ b/sections/advanced-activities/week2.html
@@ -12,28 +12,28 @@
     <form class="quiz" id="advanced-week2-quiz">
       <fieldset>
         <legend><b>Advanced Activities – Week 2 Questions</b></legend>
-        <ol>
-          <li>
-            <p>Describe how a skew chisel can be used to achieve a smooth finish on pen blanks.  When might you choose a carbide tool instead?</p>
+        
+          <div class="quiz-question">
+            <p class="question-text">Describe how a skew chisel can be used to achieve a smooth finish on pen blanks.  When might you choose a carbide tool instead?</p>
             <textarea name="adv2_q1" placeholder="Write your answer here..."></textarea>
-          </li>
-          <li>
-            <p>Explain why epoxy or polyurethane adhesives may be chosen over cyanoacrylate (CA) glue when gluing tubes into pen blanks.  Discuss advantages and disadvantages.</p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">Explain why epoxy or polyurethane adhesives may be chosen over cyanoacrylate (CA) glue when gluing tubes into pen blanks.  Discuss advantages and disadvantages.</p>
             <textarea name="adv2_q2" placeholder="Write your answer here..."></textarea>
-          </li>
-          <li>
-            <p>Identify two problems that can occur if the lathe speed is set too high when turning acrylic or resin blanks, and explain how to avoid them.</p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">Identify two problems that can occur if the lathe speed is set too high when turning acrylic or resin blanks, and explain how to avoid them.</p>
             <textarea name="adv2_q3" placeholder="Write your answer here..."></textarea>
-          </li>
-          <li>
-            <p>Outline the steps to apply a CA finish to a pen blank and explain why this finish is popular among pen makers.</p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">Outline the steps to apply a CA finish to a pen blank and explain why this finish is popular among pen makers.</p>
             <textarea name="adv2_q4" placeholder="Write your answer here..."></textarea>
-          </li>
-          <li>
-            <p>Suggest one creative method for customising a pen (such as inlays, segmented blanks or resin casting) and describe the challenges this might introduce.</p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">Suggest one creative method for customising a pen (such as inlays, segmented blanks or resin casting) and describe the challenges this might introduce.</p>
             <textarea name="adv2_q5" placeholder="Write your answer here..."></textarea>
-          </li>
-        </ol>
+          </div>
+        
         <button class="check-btn" type="button" onclick="submitAdvancedQuiz(this, 'A002')">Submit Responses</button>
         <span class="quiz-msg"></span>
       </fieldset>

--- a/sections/advanced-activities/week3.html
+++ b/sections/advanced-activities/week3.html
@@ -12,24 +12,24 @@
     <form class="quiz" id="advanced-week3-quiz">
       <fieldset>
         <legend><b>Advanced Activities – Week 3 Questions</b></legend>
-        <ol>
-          <li>
-            <p>Write a short evaluation of your completed pen using at least three of the criteria listed above (functionality, fit and finish, aesthetics, ergonomics, durability, sustainability).  Give specific examples to justify your assessment.</p>
+        
+          <div class="quiz-question">
+            <p class="question-text">Write a short evaluation of your completed pen using at least three of the criteria listed above (functionality, fit and finish, aesthetics, ergonomics, durability, sustainability).  Give specific examples to justify your assessment.</p>
             <textarea name="adv3_q1" placeholder="Write your answer here..."></textarea>
-          </li>
-          <li>
-            <p>Reflect on the turning process: what challenges did you face and how did you overcome them?  If you were to make another pen, what would you do differently?</p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">Reflect on the turning process: what challenges did you face and how did you overcome them?  If you were to make another pen, what would you do differently?</p>
             <textarea name="adv3_q2" placeholder="Write your answer here..."></textarea>
-          </li>
-          <li>
-            <p>Propose at least two ways you could improve your pen design or production process for future projects.  Explain why these changes would be beneficial.</p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">Propose at least two ways you could improve your pen design or production process for future projects.  Explain why these changes would be beneficial.</p>
             <textarea name="adv3_q3" placeholder="Write your answer here..."></textarea>
-          </li>
-          <li>
-            <p>Identify a common problem that can occur during turning or assembly (e.g. cracks, mechanism misalignment, dull finish).  Describe how you would troubleshoot and fix this problem.</p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">Identify a common problem that can occur during turning or assembly (e.g. cracks, mechanism misalignment, dull finish).  Describe how you would troubleshoot and fix this problem.</p>
             <textarea name="adv3_q4" placeholder="Write your answer here..."></textarea>
-          </li>
-        </ol>
+          </div>
+        
         <button class="check-btn" type="button" onclick="submitAdvancedQuiz(this, 'A003')">Submit Responses</button>
         <span class="quiz-msg"></span>
       </fieldset>

--- a/sections/main-theory/week1.html
+++ b/sections/main-theory/week1.html
@@ -13,64 +13,62 @@
     <form class="quiz" id="main-week1-quiz">
       <fieldset>
         <legend><b>Main Activities – Week 1 Quiz</b></legend>
-        <ol>
-          <li>
-            <p>Alex drops a heavy tool bag on the workshop floor and immediately starts using a machine without checking with the teacher. Which action is the biggest safety risk? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+          <div class="quiz-question">
+            <p class="question-text">Alex drops a heavy tool bag on the workshop floor and immediately starts using a machine without checking with the teacher. Which action is the biggest safety risk? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="main1_q1" value="A"> Placing his bag on the floor where people walk.</label>
             <label><input type="radio" name="main1_q1" value="B" data-correct="true"> Starting to use a machine without ensuring the area is clear and without permission.</label>
             <label><input type="radio" name="main1_q1" value="C"> Carrying many tools in one bag instead of multiple trips.</label>
             <label><input type="radio" name="main1_q1" value="D"> Working by himself without a partner.</label>
-          </li>
-          <li>
-            <p>Mia sees an extension cord across the walkway but decides to leave it. Why is this dangerous and what should she do first? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">Mia sees an extension cord across the walkway but decides to leave it. Why is this dangerous and what should she do first? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="main1_q2" value="A"> It could fray the cord – she should tape it down and keep working.</label>
             <label><input type="radio" name="main1_q2" value="B" data-correct="true"> Someone could trip – she should immediately move or tape down the cord before continuing.</label>
             <label><input type="radio" name="main1_q2" value="C"> It isn’t dangerous because the floor is dry.</label>
             <label><input type="radio" name="main1_q2" value="D"> It’s only an issue if water is on the floor.</label>
-          </li>
-          <li>
-            <p>Jordan’s long hair comes loose as he turns on the lathe. What could happen, and what should he do? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">Jordan’s long hair comes loose as he turns on the lathe. What could happen, and what should he do? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="main1_q3" value="A" data-correct="true"> The hair could get caught and pull his head toward the lathe – he should stop and tie it back completely before using the machine.</label>
             <label><input type="radio" name="main1_q3" value="B"> Loose strands aren’t a problem once he has goggles on.</label>
             <label><input type="radio" name="main1_q3" value="C"> Loose hair will help keep dust out of his face.</label>
             <label><input type="radio" name="main1_q3" value="D"> The worst that can happen is his hair gets cut off.</label>
-          </li>
-          <li>
-            <p>Sophie’s safety goggles fall off while sanding, but she keeps working. Why is this unsafe, and what should she do? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">Sophie’s safety goggles fall off while sanding, but she keeps working. Why is this unsafe, and what should she do? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="main1_q4" value="A" data-correct="true"> She risks an eye injury; she should stop, refit or replace her goggles before continuing.</label>
             <label><input type="radio" name="main1_q4" value="B"> She can just hold the goggles in place with one hand.</label>
             <label><input type="radio" name="main1_q4" value="C"> Small particles aren’t a big deal – she can finish quickly.</label>
             <label><input type="radio" name="main1_q4" value="D"> The teacher should finish sanding for her.</label>
-          </li>
-          <li>
-            <p>Sam leaves a scrap piece of timber in the middle of the floor until the end of class. What is unsafe about this, and what should he do? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">Sam leaves a scrap piece of timber in the middle of the floor until the end of class. What is unsafe about this, and what should he do? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="main1_q5" value="A" data-correct="true"> The scrap is a tripping hazard – he should immediately move it to a scrap bin.</label>
             <label><input type="radio" name="main1_q5" value="B"> It’s not urgent; he can leave it until the end of class.</label>
             <label><input type="radio" name="main1_q5" value="C"> Only the teacher should pick up scrap wood.</label>
             <label><input type="radio" name="main1_q5" value="D"> The wood might be useful later, so leave it.</label>
-          </li>
-          <li>
-            <p>Lee notices exposed wiring under a bench and keeps working. What is the risk, and what should he do? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">Lee notices exposed wiring under a bench and keeps working. What is the risk, and what should he do? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="main1_q6" value="A"> Only a hazard if the area is wet.</label>
             <label><input type="radio" name="main1_q6" value="B" data-correct="true"> Exposed wires pose a shock or fire risk; he should inform the teacher immediately and keep others away.</label>
             <label><input type="radio" name="main1_q6" value="C"> He should plug his drill into that outlet anyway.</label>
             <label><input type="radio" name="main1_q6" value="D"> He should cover the wires with tape himself.</label>
-          </li>
-          <li>
-            <p>Brian’s pen blank wobbles on the lathe because the tailstock isn’t tight. What should he do? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">Brian’s pen blank wobbles on the lathe because the tailstock isn’t tight. What should he do? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="main1_q7" value="A" data-correct="true"> Turn off the lathe immediately and secure the work properly before restarting.</label>
             <label><input type="radio" name="main1_q7" value="B"> Ignore the wobble; it will straighten itself out.</label>
             <label><input type="radio" name="main1_q7" value="C"> Keep cutting – the wobble will sand the wood evenly.</label>
             <label><input type="radio" name="main1_q7" value="D"> The only issue is the noise; he can keep working.</label>
-          </li>
-          <li>
-            <p>Quinn arrives wearing open‑toed sandals and uses the lathe. Why is this unsafe, and what should he have worn instead? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">Quinn arrives wearing open‑toed sandals and uses the lathe. Why is this unsafe, and what should he have worn instead? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="main1_q8" value="A" data-correct="true"> Sandals expose his feet to falling tools and chips – he should wear closed‑toe, non‑slip shoes.</label>
             <label><input type="radio" name="main1_q8" value="B"> Sandals are fine if he stays on a rubber mat.</label>
             <label><input type="radio" name="main1_q8" value="C"> Foot protection only matters in metalwork.</label>
             <label><input type="radio" name="main1_q8" value="D"> As long as he doesn’t move much, sandals are okay.</label>
-          </li>
-        </ol>
+          </div>
         <button class="check-btn" type="button" onclick="submitQuiz(this, 'M001')">Check Results</button>
         <span class="quiz-msg"></span>
       </fieldset>

--- a/sections/main-theory/week2.html
+++ b/sections/main-theory/week2.html
@@ -15,78 +15,78 @@
     <form class="quiz" id="main-week2-quiz">
       <fieldset>
         <legend><b>Main Activities – Week 2 Quiz</b></legend>
-        <ol>
-          <li>
-            <p>Why do we draw a line across the wood blank before cutting it into two pieces? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+        
+          <div class="quiz-question">
+            <p class="question-text">Why do we draw a line across the wood blank before cutting it into two pieces? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="main2_q1" value="A" data-correct="true"> To ensure we can realign the grain pattern when assembling the pen so the wood grain looks continuous.</label>
             <label><input type="radio" name="main2_q1" value="B"> To make drilling easier by following the line.</label>
             <label><input type="radio" name="main2_q1" value="C"> To measure the length of the pen accurately.</label>
             <label><input type="radio" name="main2_q1" value="D"> It’s a tradition that doesn’t serve any real purpose.</label>
-          </li>
-          <li>
-            <p>When drilling the pen blank for the brass tube, why should you retract the drill bit regularly to clear out swarf? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">When drilling the pen blank for the brass tube, why should you retract the drill bit regularly to clear out swarf? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="main2_q2" value="A" data-correct="true"> Removing swarf prevents the drill from overheating and keeps the hole straight, reducing the chance of the blank cracking.</label>
             <label><input type="radio" name="main2_q2" value="B"> Because the drill will cut faster if you stop frequently.</label>
             <label><input type="radio" name="main2_q2" value="C"> To intentionally make the hole slightly larger.</label>
             <label><input type="radio" name="main2_q2" value="D"> There’s no need – you can drill straight through without stopping.</label>
-          </li>
-          <li>
-            <p>What is the purpose of roughening (scuffing) the surface of the brass tubes before gluing them into the wooden blanks? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">What is the purpose of roughening (scuffing) the surface of the brass tubes before gluing them into the wooden blanks? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="main2_q3" value="A" data-correct="true"> It creates a better surface for the glue to stick to, resulting in a stronger bond between the tube and wood.</label>
             <label><input type="radio" name="main2_q3" value="B"> It makes the brass tube shiny and clean.</label>
             <label><input type="radio" name="main2_q3" value="C"> It helps the tube slide in easier (actually it makes it slightly more resistant until glue is applied).</label>
             <label><input type="radio" name="main2_q3" value="D"> There is no purpose; it’s just something people do out of habit.</label>
-          </li>
-          <li>
-            <p>Which of these is recommended when turning the pen blanks on the lathe? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">Which of these is recommended when turning the pen blanks on the lathe? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="main2_q4" value="A" data-correct="true"> Move the chisel slowly and steadily, taking light cuts – do not force the tool into the wood.</label>
             <label><input type="radio" name="main2_q4" value="B"> Push the tool hard into the wood to remove material faster.</label>
             <label><input type="radio" name="main2_q4" value="C"> Set the lathe to its absolute top speed immediately, regardless of blank condition.</label>
             <label><input type="radio" name="main2_q4" value="D"> Keep cutting without ever stopping to check progress until the shape is complete.</label>
-          </li>
-          <li>
-            <p>What is the best practice for sanding your pen blanks on the lathe? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">What is the best practice for sanding your pen blanks on the lathe? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="main2_q5" value="A" data-correct="true"> Start with a coarse grit and gradually work to finer grits to achieve a smooth finish.</label>
             <label><input type="radio" name="main2_q5" value="B"> Use only one grit; if the tool work was good you don’t need multiple grits.</label>
             <label><input type="radio" name="main2_q5" value="C"> Press as hard as you can with sandpaper to sand faster.</label>
             <label><input type="radio" name="main2_q5" value="D"> It’s not necessary to sand if you used a sharp tool.</label>
-          </li>
-          <li>
-            <p>During assembly, how is the pen’s clip typically attached to the wooden pen body? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">During assembly, how is the pen’s clip typically attached to the wooden pen body? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="main2_q6" value="A" data-correct="true"> By pressing the clip’s cap or button into the end of the pen blank, which holds the clip in place by friction.</label>
             <label><input type="radio" name="main2_q6" value="B"> By gluing the clip onto the side of the wood.</label>
             <label><input type="radio" name="main2_q6" value="C"> By screwing it on with a tiny screw.</label>
             <label><input type="radio" name="main2_q6" value="D"> By tying it with wire.</label>
-          </li>
-          <li>
-            <p>What should you do if you notice the wooden pen barrel starting to crack while you are pressing a component (such as the nib or cap) into it? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">What should you do if you notice the wooden pen barrel starting to crack while you are pressing a component (such as the nib or cap) into it? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="main2_q7" value="A" data-correct="true"> Stop immediately, remove the component if possible and assess the crack; next time, ensure you press straight and gently.</label>
             <label><input type="radio" name="main2_q7" value="B"> Just force the part in quickly; getting it in will fix the crack.</label>
             <label><input type="radio" name="main2_q7" value="C"> Tap the part in with a hammer.</label>
             <label><input type="radio" name="main2_q7" value="D"> Ignore the crack – small cracks don’t matter.</label>
-          </li>
-          <li>
-            <p>Which of the following is part of the pen assembly process for a typical ballpoint pen kit? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">Which of the following is part of the pen assembly process for a typical ballpoint pen kit? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="main2_q8" value="A" data-correct="true"> Inserting the ink refill and the pen’s mechanism, then ensuring the pen opens and closes properly by testing it.</label>
             <label><input type="radio" name="main2_q8" value="B"> Baking the assembled pen in an oven to cure the wood.</label>
             <label><input type="radio" name="main2_q8" value="C"> Cutting the pen in half again after assembly.</label>
             <label><input type="radio" name="main2_q8" value="D"> Painting the outside of the wood after assembly.</label>
-          </li>
-          <li>
-            <p>What is a pen mandrel used for? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">What is a pen mandrel used for? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="main2_q9" value="A" data-correct="true"> Holding and spinning the pen blanks (with bushings) on the lathe so you can turn them both accurately at the same time.</label>
             <label><input type="radio" name="main2_q9" value="B"> Drilling the holes in the pen blanks.</label>
             <label><input type="radio" name="main2_q9" value="C"> Pressing the pen parts together during assembly.</label>
             <label><input type="radio" name="main2_q9" value="D"> Testing the pen.</label>
-          </li>
-          <li>
-            <p>Before turning on the lathe to start shaping your mounted pen blanks, you should always: <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">Before turning on the lathe to start shaping your mounted pen blanks, you should always: <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="main2_q10" value="A" data-correct="true"> Make sure the blanks and bushings are secured on the mandrel, the tool rest is correctly positioned and you’re wearing PPE.</label>
             <label><input type="radio" name="main2_q10" value="B"> Leave the chuck key in and wrenches on the lathe bed.</label>
             <label><input type="radio" name="main2_q10" value="C"> Take off your safety goggles for a better look.</label>
             <label><input type="radio" name="main2_q10" value="D"> Set the lathe to its highest speed no matter what.</label>
-          </li>
-        </ol>
+          </div>
+        
         <button class="check-btn" type="button" onclick="submitQuiz(this, 'M002')">Check Results</button>
         <span class="quiz-msg"></span>
       </fieldset>

--- a/sections/main-theory/week3.html
+++ b/sections/main-theory/week3.html
@@ -12,43 +12,43 @@
     <form class="quiz" id="main-week3-quiz">
       <fieldset>
         <legend><b>Main Activities – Week 3 Quiz</b></legend>
-        <ol>
-          <li>
-            <p>When evaluating your pen, which of the following is <em>not</em> a key quality indicator? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+        
+          <div class="quiz-question">
+            <p class="question-text">When evaluating your pen, which of the following is <em>not</em> a key quality indicator? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="main3_q1" value="A"> That it is made from the most expensive wood available.</label>
             <label><input type="radio" name="main3_q1" value="B" data-correct="true"> Whether the mechanism works, the fit and finish are neat and the pen feels good in the hand.</label>
             <label><input type="radio" name="main3_q1" value="C"> That the wood and metal parts are flush with no gaps.</label>
             <label><input type="radio" name="main3_q1" value="D"> That the surface is smooth and evenly polished.</label>
-          </li>
-          <li>
-            <p>Why is it important to reflect on what was easy and what was challenging when making your pen? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">Why is it important to reflect on what was easy and what was challenging when making your pen? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="main3_q2" value="A"> To criticise yourself for any mistakes.</label>
             <label><input type="radio" name="main3_q2" value="B"> To brag about your pen and compare it to others.</label>
             <label><input type="radio" name="main3_q2" value="C" data-correct="true"> Because reflection helps you identify successes and areas for improvement, which makes you a better maker.</label>
             <label><input type="radio" name="main3_q2" value="D"> It isn’t important – once the pen works you are done.</label>
-          </li>
-          <li>
-            <p>If your pen’s refill doesn’t extend properly after assembly, what is the best first step to troubleshoot the issue? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">If your pen’s refill doesn’t extend properly after assembly, what is the best first step to troubleshoot the issue? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="main3_q3" value="A" data-correct="true"> Check that the refill and mechanism are installed the right way around and fully seated.</label>
             <label><input type="radio" name="main3_q3" value="B"> Hit the pen on the table to loosen it.</label>
             <label><input type="radio" name="main3_q3" value="C"> Throw it away and start over.</label>
             <label><input type="radio" name="main3_q3" value="D"> Trim the end of the refill.</label>
-          </li>
-          <li>
-            <p>Which practice helps prevent cracks when pressing pen parts together? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">Which practice helps prevent cracks when pressing pen parts together? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="main3_q4" value="A"> Press parts quickly and firmly to get it done fast.</label>
             <label><input type="radio" name="main3_q4" value="B" data-correct="true"> Apply steady, straight pressure and stop immediately if you feel resistance.</label>
             <label><input type="radio" name="main3_q4" value="C"> Use a hammer to tap parts into place.</label>
             <label><input type="radio" name="main3_q4" value="D"> It doesn’t matter – cracks can’t be avoided.</label>
-          </li>
-          <li>
-            <p>Which of the following is a sustainable choice when selecting materials for future projects? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">Which of the following is a sustainable choice when selecting materials for future projects? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="main3_q5" value="A" data-correct="true"> Choosing timber from responsibly managed forests and finishes that are durable and low‑VOC.</label>
             <label><input type="radio" name="main3_q5" value="B"> Using endangered species of wood because it looks beautiful.</label>
             <label><input type="radio" name="main3_q5" value="C"> Picking the cheapest wood without considering its source.</label>
             <label><input type="radio" name="main3_q5" value="D"> Ignoring sustainability; it has no impact on a small project.</label>
-          </li>
-        </ol>
+          </div>
+        
         <button class="check-btn" type="button" onclick="submitQuiz(this, 'M003')">Check Results</button>
         <span class="quiz-msg"></span>
       </fieldset>

--- a/sections/support-activities/week1.html
+++ b/sections/support-activities/week1.html
@@ -11,78 +11,78 @@
     <form class="quiz" id="support-week1-quiz">
       <fieldset>
         <legend><b>Support Activities – Week 1 Quiz</b></legend>
-        <ol>
-          <li>
-            <p>What does the abbreviation “PPE” stand for? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+        
+          <div class="quiz-question">
+            <p class="question-text">What does the abbreviation “PPE” stand for? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="sup1_q1" value="A"> Practical Projects &amp; Equipment</label>
             <label><input type="radio" name="sup1_q1" value="B" data-correct="true"> Personal Protective Equipment</label>
             <label><input type="radio" name="sup1_q1" value="C"> Primary Protection Essentials</label>
             <label><input type="radio" name="sup1_q1" value="D"> Pen Polishing Exercise</label>
-          </li>
-          <li>
-            <p>Which item of PPE is most important when using the lathe? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">Which item of PPE is most important when using the lathe? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="sup1_q2" value="A"> Ear muffs to protect your hearing</label>
             <label><input type="radio" name="sup1_q2" value="B" data-correct="true"> Safety glasses to protect your eyes</label>
             <label><input type="radio" name="sup1_q2" value="C"> A baseball cap</label>
             <label><input type="radio" name="sup1_q2" value="D"> None – PPE isn’t necessary</label>
-          </li>
-          <li>
-            <p>Which of these is a <strong>safe</strong> workshop practice? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">Which of these is a <strong>safe</strong> workshop practice? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="sup1_q3" value="A" data-correct="true"> Tie back long hair and remove jewellery before using machines</label>
             <label><input type="radio" name="sup1_q3" value="B"> Wear loose sleeves so you can move freely</label>
             <label><input type="radio" name="sup1_q3" value="C"> Leave spills on the floor to dry later</label>
             <label><input type="radio" name="sup1_q3" value="D"> Run to your machine so you finish faster</label>
-          </li>
-          <li>
-            <p>Before using any machinery you should always: <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">Before using any machinery you should always: <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="sup1_q4" value="A" data-correct="true"> Get permission and instruction from your teacher</label>
             <label><input type="radio" name="sup1_q4" value="B"> Turn it on and try it out yourself</label>
             <label><input type="radio" name="sup1_q4" value="C"> Ask your friends how to use it</label>
             <label><input type="radio" name="sup1_q4" value="D"> Skip the safety rules if you are in a hurry</label>
-          </li>
-          <li>
-            <p>If you spill glue or finish on the bench you should: <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">If you spill glue or finish on the bench you should: <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="sup1_q5" value="A"> Leave it so others learn to avoid it</label>
             <label><input type="radio" name="sup1_q5" value="B"> Ask someone else to clean it up</label>
             <label><input type="radio" name="sup1_q5" value="C" data-correct="true"> Clean it immediately and tell the teacher if you need help</label>
             <label><input type="radio" name="sup1_q5" value="D"> Ignore it – it will dry eventually</label>
-          </li>
-          <li>
-            <p>What should you do first if someone is injured in the workshop? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">What should you do first if someone is injured in the workshop? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="sup1_q6" value="A" data-correct="true"> Stop what you are doing and tell the teacher immediately</label>
             <label><input type="radio" name="sup1_q6" value="B"> Keep working so you don’t fall behind</label>
             <label><input type="radio" name="sup1_q6" value="C"> Try to fix the injury yourself without telling anyone</label>
             <label><input type="radio" name="sup1_q6" value="D"> Wait until break time</label>
-          </li>
-          <li>
-            <p>Running in the workshop is: <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">Running in the workshop is: <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="sup1_q7" value="A"> Okay if you’re in a hurry</label>
             <label><input type="radio" name="sup1_q7" value="B"> Fine as long as you wear PPE</label>
             <label><input type="radio" name="sup1_q7" value="C" data-correct="true"> Never safe – always walk and be aware of others</label>
             <label><input type="radio" name="sup1_q7" value="D"> Required to build fitness</label>
-          </li>
-          <li>
-            <p>If your wood blank begins to wobble on the lathe, what should you do? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">If your wood blank begins to wobble on the lathe, what should you do? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="sup1_q8" value="A" data-correct="true"> Turn off the machine and check that the blank is secured properly before continuing</label>
             <label><input type="radio" name="sup1_q8" value="B"> Keep going – it will fix itself</label>
             <label><input type="radio" name="sup1_q8" value="C"> Push harder with the tool to stop the wobble</label>
             <label><input type="radio" name="sup1_q8" value="D"> Wobbling is normal – ignore it</label>
-          </li>
-          <li>
-            <p>Which of these could be a hazard in the workshop? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">Which of these could be a hazard in the workshop? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="sup1_q9" value="A"> Loose hair hanging down</label>
             <label><input type="radio" name="sup1_q9" value="B"> Long loose sleeves</label>
             <label><input type="radio" name="sup1_q9" value="C"> Jewellery that dangles</label>
             <label><input type="radio" name="sup1_q9" value="D" data-correct="true"> All of the above are hazards</label>
-          </li>
-          <li>
-            <p>When preparing the lathe for turning you should make sure: <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">When preparing the lathe for turning you should make sure: <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="sup1_q10" value="A" data-correct="true"> The blank is secured, the tool rest is close to the wood and you’re wearing PPE</label>
             <label><input type="radio" name="sup1_q10" value="B"> The tool rest is far away and your hair is down</label>
             <label><input type="radio" name="sup1_q10" value="C"> You don’t need to check anything</label>
             <label><input type="radio" name="sup1_q10" value="D"> You remove bushings before turning</label>
-          </li>
-        </ol>
+          </div>
+        
         <button class="check-btn" type="button" onclick="submitQuiz(this, 'S001')">Check Results</button>
         <span class="quiz-msg"></span>
       </fieldset>

--- a/sections/support-activities/week2.html
+++ b/sections/support-activities/week2.html
@@ -10,76 +10,76 @@
     <form class="quiz" id="support-week2-quiz">
       <fieldset>
         <legend><b>Support Activities – Week 2 Quiz</b></legend>
-        <ol>
-          <li>
-            <p>What is placed inside the drilled hole in each pen blank? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+        
+          <div class="quiz-question">
+            <p class="question-text">What is placed inside the drilled hole in each pen blank? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="sup2_q1" value="A" data-correct="true"> A brass tube</label>
             <label><input type="radio" name="sup2_q1" value="B"> A wooden dowel</label>
             <label><input type="radio" name="sup2_q1" value="C"> A rubber plug</label>
             <label><input type="radio" name="sup2_q1" value="D"> Nothing goes inside</label>
-          </li>
-          <li>
-            <p>Why should you pull the drill bit out regularly while drilling? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">Why should you pull the drill bit out regularly while drilling? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="sup2_q2" value="A" data-correct="true"> To remove wood chips and prevent the bit from overheating</label>
             <label><input type="radio" name="sup2_q2" value="B"> To make the hole bigger than required</label>
             <label><input type="radio" name="sup2_q2" value="C"> So you can check your phone</label>
             <label><input type="radio" name="sup2_q2" value="D"> There is no need to retract the bit</label>
-          </li>
-          <li>
-            <p>Which machine is used to shape the pen blanks into a round form? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">Which machine is used to shape the pen blanks into a round form? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="sup2_q3" value="A" data-correct="true"> The lathe</label>
             <label><input type="radio" name="sup2_q3" value="B"> A drill press</label>
             <label><input type="radio" name="sup2_q3" value="C"> A sewing machine</label>
             <label><input type="radio" name="sup2_q3" value="D"> A paintbrush</label>
-          </li>
-          <li>
-            <p>Which tool do you use to remove material and shape the spinning wood? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">Which tool do you use to remove material and shape the spinning wood? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="sup2_q4" value="A" data-correct="true"> A sharp chisel or spindle gouge</label>
             <label><input type="radio" name="sup2_q4" value="B"> A screwdriver</label>
             <label><input type="radio" name="sup2_q4" value="C"> A hammer</label>
             <label><input type="radio" name="sup2_q4" value="D"> Your hands</label>
-          </li>
-          <li>
-            <p>How do you make the surface of the pen blanks smooth? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">How do you make the surface of the pen blanks smooth? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="sup2_q5" value="A" data-correct="true"> Sand with progressively finer grits of sandpaper</label>
             <label><input type="radio" name="sup2_q5" value="B"> Tap it with a hammer</label>
             <label><input type="radio" name="sup2_q5" value="C"> Paint over the rough surface</label>
             <label><input type="radio" name="sup2_q5" value="D"> You don’t need to sand</label>
-          </li>
-          <li>
-            <p>What should you apply after sanding to protect and enhance the wood? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">What should you apply after sanding to protect and enhance the wood? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="sup2_q6" value="A" data-correct="true"> A finish such as wax or polish</label>
             <label><input type="radio" name="sup2_q6" value="B"> Glue</label>
             <label><input type="radio" name="sup2_q6" value="C"> Nothing – leave it plain</label>
             <label><input type="radio" name="sup2_q6" value="D"> Water</label>
-          </li>
-          <li>
-            <p>What is the final step in making your pen? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">What is the final step in making your pen? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="sup2_q7" value="A" data-correct="true"> Assembling the pen parts and ensuring the pen works</label>
             <label><input type="radio" name="sup2_q7" value="B"> Leaving the blanks on the lathe</label>
             <label><input type="radio" name="sup2_q7" value="C"> Drilling another hole</label>
             <label><input type="radio" name="sup2_q7" value="D"> Throwing the blanks away</label>
-          </li>
-          <li>
-            <p>How are the metal parts of the pen attached to the wooden blanks? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">How are the metal parts of the pen attached to the wooden blanks? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="sup2_q8" value="A" data-correct="true"> By pressing them in place using a clamp or pen press</label>
             <label><input type="radio" name="sup2_q8" value="B"> By gluing them on the outside</label>
             <label><input type="radio" name="sup2_q8" value="C"> By screwing them together</label>
             <label><input type="radio" name="sup2_q8" value="D"> They attach themselves automatically</label>
-          </li>
-          <li>
-            <p>True or False: It’s okay to start turning immediately after gluing the tubes into the blanks. <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">True or False: It’s okay to start turning immediately after gluing the tubes into the blanks. <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="sup2_q9" value="A" data-correct="true"> False – you must let the glue dry first</label>
             <label><input type="radio" name="sup2_q9" value="B"> True – the glue will dry while you turn</label>
-          </li>
-          <li>
-            <p>How do you know when to stop cutting your blanks on the lathe? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">How do you know when to stop cutting your blanks on the lathe? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="sup2_q10" value="A" data-correct="true"> When the wood is flush with the bushings at each end</label>
             <label><input type="radio" name="sup2_q10" value="B"> When the pen looks as small as possible</label>
             <label><input type="radio" name="sup2_q10" value="C"> When you are tired of turning</label>
             <label><input type="radio" name="sup2_q10" value="D"> It doesn’t matter, just stop whenever</label>
-          </li>
-        </ol>
+          </div>
+        
         <button class="check-btn" type="button" onclick="submitQuiz(this, 'S002')">Check Results</button>
         <span class="quiz-msg"></span>
       </fieldset>

--- a/sections/support-activities/week3.html
+++ b/sections/support-activities/week3.html
@@ -10,62 +10,62 @@
     <form class="quiz" id="support-week3-quiz">
       <fieldset>
         <legend><b>Support Activities – Week 3 Quiz</b></legend>
-        <ol>
-          <li>
-            <p>After finishing your pen, what should you do first? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+        
+          <div class="quiz-question">
+            <p class="question-text">After finishing your pen, what should you do first? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="sup3_q1" value="A"> Start making another pen immediately</label>
             <label><input type="radio" name="sup3_q1" value="B" data-correct="true"> Test that it writes and check that all parts fit together neatly</label>
             <label><input type="radio" name="sup3_q1" value="C"> Give it to a friend without checking anything</label>
             <label><input type="radio" name="sup3_q1" value="D"> Hide it in your bag</label>
-          </li>
-          <li>
-            <p>Why should there be no gaps between the wood and the metal parts of the pen? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">Why should there be no gaps between the wood and the metal parts of the pen? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="sup3_q2" value="A" data-correct="true"> Gaps look untidy and can cause parts to loosen over time</label>
             <label><input type="radio" name="sup3_q2" value="B"> Gaps make the pen lighter</label>
             <label><input type="radio" name="sup3_q2" value="C"> Gaps help the glue dry faster</label>
             <label><input type="radio" name="sup3_q2" value="D"> Gaps are needed for air flow</label>
-          </li>
-          <li>
-            <p>If the nib doesn’t come out when you twist or click the pen, what should you check? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">If the nib doesn’t come out when you twist or click the pen, what should you check? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="sup3_q3" value="A" data-correct="true"> The ink refill and mechanism to make sure they are installed correctly</label>
             <label><input type="radio" name="sup3_q3" value="B"> The colour of the wood</label>
             <label><input type="radio" name="sup3_q3" value="C"> Your handwriting</label>
             <label><input type="radio" name="sup3_q3" value="D"> How hard you twist the pen</label>
-          </li>
-          <li>
-            <p>If something feels loose or out of place on your finished pen, what should you do? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">If something feels loose or out of place on your finished pen, what should you do? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="sup3_q4" value="A"> Ignore it – it will probably be fine</label>
             <label><input type="radio" name="sup3_q4" value="B"> Take the pen apart and force the parts together</label>
             <label><input type="radio" name="sup3_q4" value="C" data-correct="true"> Stop using it and ask your teacher for guidance</label>
             <label><input type="radio" name="sup3_q4" value="D"> Throw the pen away</label>
-          </li>
-          <li>
-            <p>True or False: Reflecting on what was easy and what was hard helps you improve your skills. <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">True or False: Reflecting on what was easy and what was hard helps you improve your skills. <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="sup3_q5" value="A" data-correct="true"> True</label>
             <label><input type="radio" name="sup3_q5" value="B"> False</label>
-          </li>
-          <li>
-            <p>If your wood cracked while pressing the pen parts together, what could you do differently next time? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">If your wood cracked while pressing the pen parts together, what could you do differently next time? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="sup3_q6" value="A" data-correct="true"> Press slowly and keep the parts straight</label>
             <label><input type="radio" name="sup3_q6" value="B"> Hit the pen harder with a hammer</label>
             <label><input type="radio" name="sup3_q6" value="C"> Don’t use any glue</label>
             <label><input type="radio" name="sup3_q6" value="D"> Crack the wood on purpose next time</label>
-          </li>
-          <li>
-            <p>Why is it important to be honest about any problems you encountered when you evaluate your pen? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">Why is it important to be honest about any problems you encountered when you evaluate your pen? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="sup3_q7" value="A" data-correct="true"> So you can learn from them and do better next time</label>
             <label><input type="radio" name="sup3_q7" value="B"> So you can blame someone else</label>
             <label><input type="radio" name="sup3_q7" value="C"> It isn’t important – hide your mistakes</label>
             <label><input type="radio" name="sup3_q7" value="D"> To discourage others from making pens</label>
-          </li>
-          <li>
-            <p>Which of the following is a helpful comment when evaluating your pen? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
+          </div>
+          <div class="quiz-question">
+            <p class="question-text">Which of the following is a helpful comment when evaluating your pen? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
             <label><input type="radio" name="sup3_q8" value="A"> “My pen is fine; I don’t need to check anything.”</label>
             <label><input type="radio" name="sup3_q8" value="B" data-correct="true"> “The shape feels comfortable and the surface is smooth, but there’s a small gap at the nib I’ll fix next time.”</label>
             <label><input type="radio" name="sup3_q8" value="C"> “It doesn’t matter if the mechanism works; it looks cool.”</label>
             <label><input type="radio" name="sup3_q8" value="D"> “The wood cracked – oh well, I’ll ignore it.”</label>
-          </li>
-        </ol>
+          </div>
+        
         <button class="check-btn" type="button" onclick="submitQuiz(this, 'S003')">Check Results</button>
         <span class="quiz-msg"></span>
       </fieldset>


### PR DESCRIPTION
## Summary
- convert quiz HTML to single-column layout using `.quiz-question` blocks
- update site CSS for the new quiz layout
- adjust quiz JavaScript to work with `.quiz-question` containers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688444e44c98832684f9eb7bd0eea357