### PR TITLE
Fix spacing in quiz answers

### DIFF
--- a/index.html
+++ b/index.html
@@ -558,9 +558,8 @@ function shuffleQuizAnswers() {
       const j = Math.floor(Math.random() * (i + 1));
       [labels[i], labels[j]] = [labels[j], labels[i]];
     }
-    labels.forEach((label, idx) => {
+    labels.forEach(label => {
       q.appendChild(label);
-      if (idx < labels.length - 1) q.appendChild(document.createElement('br'));
     });
   });
 }


### PR DESCRIPTION
## Summary
- stop inserting `<br>` elements after shuffled answers to tighten quiz spacing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68844c56ff608326a519edb1fb691034