### PR TITLE
Fix quiz legends layout and remove 404 placeholders

### DIFF
--- a/index.html
+++ b/index.html
@@ -195,6 +195,8 @@
     .quiz legend {
       font-weight: bold;
       margin-bottom: 10px;
+      text-align: center; /* centre quiz titles */
+      padding: 0 5px;      /* prevent text from overlapping fieldset border */
     }
     /* Style for audio buttons */
     .quiz button[aria-label^="Read"] {

--- a/loadSections.js
+++ b/loadSections.js
@@ -8,10 +8,11 @@ const sections = [
   'advanced-activities'
 ];
 
+// Only load weeks that actually exist to avoid 404 errors being injected
 const weekCounts = {
-  'main-theory': 10,
-  'support-activities': 10,
-  'advanced-activities': 10
+  'main-theory': 3,
+  'support-activities': 3,
+  'advanced-activities': 3
 };
 
 function loadSections() {


### PR DESCRIPTION
## Summary
- prevent quiz legends from overlapping the fieldset border and centre them
- stop loading non-existent week pages to remove 404 messages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688451586b5883269324b02cefb2dc41