### PR TITLE
Fix layout glitches and suppress 404 inserts

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
     }
     header h1 {
       font-size: 2.5em;
-      text-align: center;
+      text-align: center !important;
     }
     header p {
       font-size: 1.2em;
@@ -197,6 +197,7 @@
       margin-bottom: 10px;
       text-align: center; /* centre quiz titles */
       padding: 0 5px;      /* prevent text from overlapping fieldset border */
+      display: block;      /* ensure legend sits inside the box */
     }
     /* Style for audio buttons */
     .quiz button[aria-label^="Read"] {

--- a/loadSections.js
+++ b/loadSections.js
@@ -18,7 +18,7 @@ const weekCounts = {
 function loadSections() {
   return Promise.all(sections.map(id => {
     return fetch('sections/' + id + '.html')
-      .then(resp => resp.text())
+      .then(resp => resp.ok ? resp.text() : '')
       .then(html => {
         const el = document.getElementById(id);
         if (el) el.innerHTML = html;
@@ -32,6 +32,7 @@ async function loadWeeks() {
     if (!container) return;
     for (let i = 1; i <= count; i++) {
       const resp = await fetch(`sections/${section}/week${i}.html`);
+      if (!resp.ok) continue;
       const html = await resp.text();
       const div = document.createElement('div');
       div.innerHTML = html;


### PR DESCRIPTION
## Summary
- ensure header title always stays centered
- keep quiz legends inside their fieldset
- don't inject GitHub's 404 page when optional files are missing

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_6884530408808326b9fce1bface4ff6f